### PR TITLE
Add RooHistPdf to available fit models

### DIFF
--- a/examples/histogram_template_fit.py
+++ b/examples/histogram_template_fit.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+""" Simple fit to a histogram template
+
+In this example a template histogram is created from the given data
+
+The number of bins must be specified
+"""
+
+from pyroofit.models import HistPDF
+import numpy as np
+# import ROOT
+
+template_data = np.random.normal(0, 1, 1000)
+
+pdf = HistPDF(
+    ('x', -3, 3),
+    template_data,
+    nbins=10,
+)
+pdf.plot('example_hist.pdf')
+pdf.get()

--- a/examples/histogram_template_fit.py
+++ b/examples/histogram_template_fit.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 """ Simple fit to a histogram template
 
-In this example a template histogram is created from the given data
-
-The number of bins must be specified
+In this example a template histogram is created from some data.
+Then the template is fixed and fitted to some new data containing a different number of entries.
 """
 
 from pyroofit.models import HistPDF
+from pyroofit.composites import AddPdf
 import numpy as np
 # import ROOT
 
+# First we build the template of some data
 template_data = np.random.normal(0, 1, 1000)
 
 pdf = HistPDF(
@@ -18,4 +19,13 @@ pdf = HistPDF(
     nbins=10,
 )
 pdf.plot('example_hist.pdf')
+pdf.fix()
 pdf.get()
+
+# And now we can fit that template to some new data to measure the yield
+fit_data = np.random.normal(0, 1, 5000)
+
+pdf2 = AddPdf([pdf])
+pdf2.fit(fit_data)
+# pdf2.plot('example_hist.pdf')  # Bug causes this to error atm
+pdf2.get()

--- a/src/pyroofit/models.py
+++ b/src/pyroofit/models.py
@@ -305,21 +305,19 @@ class HistPDF(PDF):
     '''
     def __init__(self,
                  observable,
+                 df,
+                 nbins,
+                 weights=None,
                  name='histPDF',
+                 *args,
                  **kwds):
         super(HistPDF, self).__init__(name=name, **kwds)
 
         self.add_observable(observable)
 
-    def fit(self, df, weights=None, nbins=None, *args, **kwargs):
-        ''' Create the PDF from the data histogram
-
-        '''
-        self.logger.debug("Fitting")
-
         # Data must be binned to fit a RooHistPdf
-        assert isinstance(nbins, int), self.logger.error("nbins must be specified in fit() to perform histogram template fit")
-        self.last_data = self.get_fit_data(df, weights=weights, nbins=nbins, *args, **kwargs)
+        assert isinstance(nbins, int), self.logger.error("nbins must be integer")
+        self.last_data = self.get_fit_data(df, weights=weights, nbins=nbins, *args, **kwds)
 
         self.roo_pdf = ROOT.RooHistPdf(self.name,
                                        self.title,

--- a/src/pyroofit/models.py
+++ b/src/pyroofit/models.py
@@ -299,6 +299,34 @@ class KernelDensityProd(ProdPdf):
         self.init_pdf()
 
 
+class HistPDF(PDF):
+    ''' Histogram template PDF
+
+    '''
+    def __init__(self,
+                 observable,
+                 name='histPDF',
+                 **kwds):
+        super(HistPDF, self).__init__(name=name, **kwds)
+
+        self.add_observable(observable)
+
+    def fit(self, df, weights=None, nbins=None, *args, **kwargs):
+        ''' Create the PDF from the data histogram
+
+        '''
+        self.logger.debug("Fitting")
+
+        # Data must be binned to fit a RooHistPdf
+        assert isinstance(nbins, int), self.logger.error("nbins must be specified in fit() to perform histogram template fit")
+        self.last_data = self.get_fit_data(df, weights=weights, nbins=nbins, *args, **kwargs)
+
+        self.roo_pdf = ROOT.RooHistPdf(self.name,
+                                       self.title,
+                                       ROOT.RooArgSet(next(iter(self.observables.values()))),
+                                       self.last_data)
+
+
 class DstD0BG(PDF):
     """ ROOT.RooDstD0BG for D0-D* mass difference
     [ 1-exp{ (dm-dm0) / c} ] * (dm/dm0)**a + b*(dm/dm0 - 1)


### PR DESCRIPTION
This PR adds an implementation of RooHistPdf to the models.py as HistPDF.
An example of usage is also added as the initialisation and fit procedure differs from standard the PDFs.